### PR TITLE
Allow the user to override the nm executable with an env variable.

### DIFF
--- a/elfsize.py
+++ b/elfsize.py
@@ -4,10 +4,17 @@ from __future__ import print_function
 from subprocess import check_output
 from collections import OrderedDict
 from os import path
+from os import environ
 import re, os, json
 
 # arm-none-eabi-nm needs to be in the environment path
 nm = "arm-none-eabi-nm"
+try:
+    nm = os.environ['NM']
+except KeyError:
+    # Keep default
+    pass
+
 nm_opts = "-l -S -C -f sysv"
 default_datafile = "data-flare.js"
 repo_root = path.dirname(path.abspath(__file__))


### PR DESCRIPTION
Some users may not use arm-none-eabi- toolchains.  For instance a
custom built toolchain could be prefixed with armv6m-none-eabi-.  This
allows the user to override the default nm binary name.