### PR TITLE
Port string massaging calls to python3 in elfsize.py.

### DIFF
--- a/elfsize.py
+++ b/elfsize.py
@@ -35,8 +35,8 @@ def output_to_file(fd, root):
     # write dict as json to output file
     s = json.dumps(dict(root), indent=4)
     fd.seek(0)
-    fd.write("var mbed_map = ")
-    fd.write(s)
+    fd.write("var mbed_map = ".encode('utf8'))
+    fd.write(s.encode('utf8'))
     fd.truncate()
 
 def main(binaries, output):
@@ -45,7 +45,7 @@ def main(binaries, output):
         # run nm command on binary
         cmd = [nm] + nm_opts.split() + [binary]
         print(" ".join(cmd))
-        op += check_output(cmd).strip()
+        op += check_output(cmd).decode('utf8').strip()
 
     # parse output and store in dict
     root = OrderedDict({"name": "mbed", "children": []})


### PR DESCRIPTION
The biggest difference between python3 and python2 is that many APIs
that used to accept strings now require bytes.  This is a simple change
just setting the default en/decoding to utf8 to move to/from bytes.