### PR TITLE
Fixes for windows / python3

### DIFF
--- a/elfsize.py
+++ b/elfsize.py
@@ -35,8 +35,8 @@ def output_to_file(fd, root):
     # write dict as json to output file
     s = json.dumps(dict(root), indent=4)
     fd.seek(0)
-    fd.write("var mbed_map = ")
-    fd.write(s)
+    fd.write(("var mbed_map = ").encode())
+    fd.write(s.encode())
     fd.truncate()
 
 def main(binaries, output):
@@ -45,7 +45,7 @@ def main(binaries, output):
         # run nm command on binary
         cmd = [nm] + nm_opts.split() + [binary]
         print(" ".join(cmd))
-        op += check_output(cmd).strip()
+        op += check_output(cmd).decode().strip()
 
     # parse output and store in dict
     root = OrderedDict({"name": "mbed", "children": []})


### PR DESCRIPTION
Encountered following errors before fix:

```
arm-none-eabi-nm -l -S -C -f sysv sketch_jan04a/sketch_jan04a.ino.elf
Traceback (most recent call last):
  File "mbed-os-linker-report/elfsize.py", line 94, in <module>
    main(args.binary, args.output)
  File "mbed-os-linker-report/elfsize.py", line 48, in main
    op += check_output(cmd).strip()
TypeError: can only concatenate str (not "bytes") to str
```

```
arm-none-eabi-nm -l -S -C -f sysv sketch_jan04a/sketch_jan04a.ino.elf
Traceback (most recent call last): 
  File "mbed-os-linker-report/elfsize.py", line 94, in <module>
    main(args.binary, args.output)
  File "mbed-os-linker-report/elfsize.py", line 67, in main
    output_to_file(output, root)
  File "mbed-os-linker-report/elfsize.py", line 38, in output_to_file
    fd.write("var mbed_map = ")
TypeError: a bytes-like object is required, not 'str'
```

```
arm-none-eabi-nm -l -S -C -f sysv sketch_jan04a/sketch_jan04a.ino.elf
Traceback (most recent call last):
  File "mbed-os-linker-report/elfsize.py", line 94, in <module>
    main(args.binary, args.output)
  File "mbed-os-linker-report/elfsize.py", line 67, in main
    output_to_file(output, root)
  File "mbed-os-linker-report/elfsize.py", line 39, in output_to_file
    fd.write(s)
TypeError: a bytes-like object is required, not 'str'
```